### PR TITLE
Compatibility with newer CoreJS.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,18 +6,10 @@
         "node": "6"
       },
       "loose": true,
-      "useBuiltIns": "usage"
+      "useBuiltIns": false
     }],
     "@babel/preset-stage-3",
     "@babel/typescript"
-  ],
-  "plugins": [
-    ["@babel/plugin-transform-runtime", {
-      "helpers": true,
-      "polyfill": false,
-      "regenerator": false,
-      "moduleName": "@babel/runtime"
-    }]
   ],
   "env": {
     "test": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.35",
     "@babel/core": "^7.0.0-beta.35",
-    "@babel/plugin-transform-runtime": "^7.0.0-beta.35",
     "@babel/preset-env": "^7.0.0-beta.35",
     "@babel/preset-stage-3": "^7.0.0-beta.35",
     "@babel/preset-typescript": "^7.0.0-beta.35",
@@ -108,7 +107,6 @@
     "yaml-loader": "^0.5.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.35",
     "loader-utils": "^1.1.0"
   }
 }


### PR DESCRIPTION
This PR tweaks the Babel config to prevent the built files from implicitly depending on specific versions of CoreJS and `@babel/runtime`.

With `@babel/env`'s `useBuiltIns` feature enabled, Babel tries to import polyfills from CoreJS. This works fine if everyone consuming the package is on roughly the same version, but those of us using CoreJS 3 would see an error like this:

```
ERROR in   Error: Child compilation failed:
  Module build failed (from ../node_modules/extract-loader/lib/extractLoader.js):
  ModuleBuildError: Module build failed (from ../node_modules/json-import-loader/index.js):
  Error: Cannot find module 'core-js/modules/es6.regexp.replace'
  Require stack:
  - /Users/daniel/Repos/Tryworks/browser-extension/node_modules/json-import-loader/lib/loader.js
  - /Users/daniel/Repos/Tryworks/browser-extension/node_modules/json-import-loader/index.js
```

Enabling `@babel/transform-runtime` introduces a similar issue: Babel will add imports from `@babel/runtime`, obliging the user to stay pinned to this package's version.

Removing both adds negligible additional code, especially considering that it'll be executed at build time rather than runtime.